### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## v0.1.0 (2024-07-03)
+
+[Full Changelog](https://github.com/main-branch/command_line_boss/compare/6cafbd0..v0.1.0)
+
+Changes:
+
+* 8051772 Remove JRuby build
+* 6c60ac0 Integrate turnip for testing
+* 07a983d Update CodeClimate test reporter id
+* d605a91 Remove the JRuby windows build
+* da7b1d3 Use minimum supported Ruby (3.1) on Windows
+* bcbddef Define the CI build with Github Actions
+* 0c9be2b Add create_github_release to the project
+* ef55727 Define default rake task
+* 541f2f8 Integrate YARD
+* aa171ea Autocorrect all rubocop offenses
+* c151f47 Integrate Rubocop
+* ba8054e Integrate RSpec
+* 421ea2d Add gem build to Rakefile, exclude /Gemfile.lock, fix rubocop typo
+* d9a9cd6 Integrate Bundler Audit
+* b38761f Start with an empty Rakefile
+* 3972ad8 Define homepage, source, changelog, and doc links
+* 4c1fdf8 Allow the CommandLineBoss gem to be pushed to rubygems
+* 81ea3e2 Require Ruby 3.1.0 or later
+* 4b5fc63 Set gemspec summary and description
+* f5ed145 Move dev dependencies to the gemspec
+* 6cafbd0 Generated version
+
 ## [Unreleased]
 
 ## [0.1.0] - 2024-05-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## v0.1.0 (2024-07-03)
 
 [Full Changelog](https://github.com/main-branch/command_line_boss/compare/6cafbd0..v0.1.0)
@@ -25,9 +32,3 @@ Changes:
 * 4b5fc63 Set gemspec summary and description
 * f5ed145 Move dev dependencies to the gemspec
 * 6cafbd0 Generated version
-
-## [Unreleased]
-
-## [0.1.0] - 2024-05-29
-
-- Initial release


### PR DESCRIPTION
# Release PR

## v0.1.0 (2024-07-03)

[Full Changelog](https://github.com/main-branch/command_line_boss/compare/6cafbd0..v0.1.0)

Changes:

* 8051772 Remove JRuby build
* 6c60ac0 Integrate turnip for testing
* 07a983d Update CodeClimate test reporter id
* d605a91 Remove the JRuby windows build
* da7b1d3 Use minimum supported Ruby (3.1) on Windows
* bcbddef Define the CI build with Github Actions
* 0c9be2b Add create_github_release to the project
* ef55727 Define default rake task
* 541f2f8 Integrate YARD
* aa171ea Autocorrect all rubocop offenses
* c151f47 Integrate Rubocop
* ba8054e Integrate RSpec
* 421ea2d Add gem build to Rakefile, exclude /Gemfile.lock, fix rubocop typo
* d9a9cd6 Integrate Bundler Audit
* b38761f Start with an empty Rakefile
* 3972ad8 Define homepage, source, changelog, and doc links
* 4c1fdf8 Allow the CommandLineBoss gem to be pushed to rubygems
* 81ea3e2 Require Ruby 3.1.0 or later
* 4b5fc63 Set gemspec summary and description
* f5ed145 Move dev dependencies to the gemspec
* 6cafbd0 Generated version
