### PR TITLE
Update continuous integration and experimental ruby builds

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: Continuous Integration
 
 on:
   push:
@@ -7,22 +7,33 @@ on:
   pull_request:
     branches: [main]
 
+  workflow_dispatch:
+
+# Supported platforms / Ruby versions:
+#  - Ubuntu: MRI (3.1, 3.2, 3.3), TruffleRuby (24), JRuby (9.4)
+#  - Windows: MRI (3.1), JRuby (9.4)
+
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+
     runs-on: ${{ matrix.operating-system }}
-    continue-on-error: ${{ matrix.experimental == 'Yes' }}
+    continue-on-error: true
 
     strategy:
+      fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", head]
+        ruby: ["3.1", "3.2", "3.3", "jruby-9.4", "truffleruby-24"]
         operating-system: [ubuntu-latest]
-        experimental: [No]
         include:
           - ruby: "3.1"
             operating-system: windows-latest
-          - ruby: head
-            operating-system: ubuntu-latest
+          - ruby: "jruby-9.4"
+            operating-system: windows-latest
+
+    env:
+      JAVA_OPTS: -Djdk.io.File.enableADS=true
+      JRUBY_OPTS: --debug
 
     steps:
       - name: Checkout
@@ -38,10 +49,10 @@ jobs:
         run: bundle exec rake
 
   coverage:
+    name: Report test coverage to CodeClimate
+
     needs: [build]
     runs-on: ubuntu-latest
-
-    name: Report test coverage to CodeClimate
 
     steps:
       - name: Checkout
@@ -53,12 +64,10 @@ jobs:
           ruby-version: 3.1
           bundler-cache: true
 
-      - name: Run tests
-        run: bundle exec rake spec
-
       - name: Report test coverage
-        uses: paambaati/codeclimate-action@v6.0.0
+        uses: paambaati/codeclimate-action@v9
         env:
           CC_TEST_REPORTER_ID: 59b5645f30f1d2737a5811628e315c026c5ea2aeced2d77dae4b7b394a85e966
         with:
+          coverageCommand: bundle exec rake spec
           coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -1,0 +1,46 @@
+name: Experimental Ruby Builds
+
+on:
+  push:
+    branches: [main]
+
+  workflow_dispatch:
+
+# Experimental platforms / Ruby versions:
+#  - Ubuntu: MRI (head), TruffleRuby (head), JRuby (head)
+#  - Windows: MRI (head), JRuby (head)
+
+jobs:
+  build:
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+    
+    runs-on: ${{ matrix.operating-system }}
+    continue-on-error: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: head
+            operating-system: ubuntu-latest
+          - ruby: head
+            operating-system: windows-latest
+          - ruby: truffleruby-head
+            operating-system: ubuntu-latest
+          - ruby: jruby-head
+            operating-system: ubuntu-latest
+          - ruby: jruby-head
+            operating-system: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run rake
+        run: bundle exec rake

--- a/command_line_boss.gemspec
+++ b/command_line_boss.gemspec
@@ -38,17 +38,21 @@ Gem::Specification.new do |spec|
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.requirements = [
+    'Platform: Mac, Linux, or Windows',
+    'Ruby: MRI 3.1 or later, TruffleRuby 24 or later, or JRuby 9.4 or later'
+  ]
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
-  spec.add_development_dependency 'create_github_release', '~> 1.4'
+  spec.add_development_dependency 'create_github_release', '~> 1.5'
   spec.add_development_dependency 'csv', '~> 3.3'
   spec.add_development_dependency 'fuubar', '~> 2.5'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
-  spec.add_development_dependency 'rubocop', '~> 1.64'
+  spec.add_development_dependency 'rubocop', '~> 1.66'
   spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
   spec.add_development_dependency 'turnip', '~> 4.4'

--- a/spec/command_line_boss.feature
+++ b/spec/command_line_boss.feature
@@ -8,7 +8,11 @@ Feature: Defining a command line parser
       """
       private
 
-      def set_defaults; end
+      attr_reader :set_defaults_called
+
+      def set_defaults
+        @set_defaults_called = true
+      end
       """
     When an instance of the "CommandLine" class is created
     Then the "set_defaults" method should have been called
@@ -18,11 +22,15 @@ Feature: Defining a command line parser
       """
       attr_reader :users, :verbose
 
+      # For testing
+      attr_reader :set_defaults_called
+
       private
 
       def set_defaults
         @users = []
         @verbose = false
+        @set_defaults_called = true
       end
       """
     When an instance of the "CommandLine" class is created
@@ -36,13 +44,21 @@ Feature: Defining a command line parser
 
       private
 
+      # For testing
+      attr_reader :define_user_option_called, :define_verbose_option_called
+
       def set_defaults
         @users = []
         @verbose = false
       end
 
-      def define_user_option; end
-      def define_verbose_option; end
+      def define_user_option
+        @define_user_option_called = true
+      end
+
+      def define_verbose_option
+        @define_verbose_option_called = true
+      end
       """
     When an instance of the "CommandLine" class is created
     Then the "define_user_option" method should have been called

--- a/spec/command_line_boss_parse.feature
+++ b/spec/command_line_boss_parse.feature
@@ -5,11 +5,15 @@ Feature: Parsing the command line
       """
       attr_reader :users, :verbose
 
+      # For testing
+      attr_reader :set_defaults_called, :define_user_option_called, :define_verbose_option_called
+
       private
 
       def set_defaults
         @users = []
         @verbose = false
+        @set_defaults_called = true
       end
 
       def define_user_option
@@ -21,12 +25,14 @@ Feature: Parsing the command line
 
           @users << user
         end
+        @define_user_option_called = true
       end
 
       def define_verbose_option
         @parser.on("-v", "--[no-]verbose", "Run verbosely") do |verbose|
           @verbose = verbose
         end
+        @define_verbose_option_called = true
       end
       """
     And an instance of the "CommandLine" class is created

--- a/spec/command_line_boss_steps.rb
+++ b/spec/command_line_boss_steps.rb
@@ -28,17 +28,7 @@ end
 
 step 'an instance of the :class_name class is created' do |class_name, program_name = nil|
   klass = @klasses[class_name]
-  trace = TracePoint.new(:call) do |tp|
-    next unless tp.self.is_a?(klass)
-
-    next if tp.method_id == :definition_method?
-
-    @methods_called ||= []
-    @methods_called << tp.method_id
-  end
-  trace.enable do
-    @instance = klass.new(program_name: program_name) # rubocop:disable Style/HashSyntax
-  end
+  @instance = klass.new(program_name:)
 end
 
 step 'an instance of :class_name is created specifying the program name :program_name' do |class_name, program_name|
@@ -50,7 +40,8 @@ step 'the :attribute_name attribute should be an empty array' do |attribute_name
 end
 
 step 'the :method_name method should have been called' do |method_name|
-  expect(@methods_called).to include(method_name.to_sym)
+  test_method = :"#{method_name}_called"
+  expect(@instance.send(test_method)).to eq(true)
 end
 
 step 'the :class_name class defines the instance attribute :attribute_name' do |class_name, attribute_name|


### PR DESCRIPTION
Update continuous integration and experimental Ruby builds making the following changes:

* Change supported platforms / Ruby versions
  * Continuous integration platforms / Ruby versions:
    * Ubuntu: MRI (3.1, 3.2, 3.3), TruffleRuby (24), JRuby (9.4)
    * Windows: MRI (3.1), JRuby (9.4)
  * Experimental platforms / Ruby versions:
    * Ubuntu: MRI (head), TruffleRuby (head), JRuby (head)
    * Windows: MRI (head), JRuby (head)

* Update continuous integration and experimental ruby builds to use the same workflow for all projects (including possibly renaming the workflow file name and name)

* Update the minimally required Ruby in the project’s gemspec and .rubocop.yml

* Update dependencies to latest

* Auto correct new Rubocop offenses