### PR TITLE
Update links in gemspec

### DIFF
--- a/command_line_boss.gemspec
+++ b/command_line_boss.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
-  spec.homepage = 'https://github.com/main-branch/command_line_boss'
-
+  # Project links
+  spec.homepage = "https://github.com/main-branch/#{spec.name}"
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/main-branch/command_line_boss'
-  spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"
+  spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['documentation_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}"
+  spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Update homepage, source code, changelog, and documentation links in the gemspec.

Make sure that changelog and documentation links go to the changelog and documenation for the version of the gem the documentation is viewed from.

Source code link should always go to HEAD on the default branch.