### PR TITLE
Use shared Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,34 +1,7 @@
+inherit_gem:
+  main_branch_shared_rubocop_config: config/rubocop.yml
+
 AllCops:
-  NewCops: enable
-  SuggestExtensions: false
-  DefaultFormatter: fuubar
-
-  # Output extra information for each offense to make it easier to diagnose:
-  DisplayCopNames: true
-  DisplayStyleGuide: true
-  ExtraDetails: true
-
   # RuboCop enforces rules depending on the oldest version of Ruby which
   # your project supports:
   TargetRubyVersion: 3.1
-
-Gemspec/DevelopmentDependencies:
-  Enabled: false
-
-Layout/LineLength:
-  Max: 120
-
-# The DSL for RSpec and the gemspec file make it very hard to limit block length
-Metrics/BlockLength:
-  Exclude:
-    - '**/*_spec.rb'
-    - '*.gemspec'
-
-Metrics/ModuleLength:
-  CountAsOne: ['hash']
-
-Metrics/ClassLength:
-  CountAsOne: ['hash']
-
-Style/AsciiComments:
-  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -44,16 +44,9 @@ CLEAN << 'rspec-report.xml'
 
 require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new do |t|
-  t.options = %w[
-    --format fuubar
-    --format json --out rubocop-report.json
-    --display-cop-names
-    --config .rubocop.yml
-  ]
-end
+RuboCop::RakeTask.new
 
-CLEAN << 'rubocop-report.json'
+# YARD
 
 unless RUBY_PLATFORM == 'java'
   # yard:build

--- a/command_line_boss.gemspec
+++ b/command_line_boss.gemspec
@@ -46,10 +46,12 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
 
+  spec.add_dependency 'logger', '~> 1.6'
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
   spec.add_development_dependency 'create_github_release', '~> 1.5'
   spec.add_development_dependency 'csv', '~> 3.3'
   spec.add_development_dependency 'fuubar', '~> 2.5'
+  spec.add_development_dependency 'main_branch_shared_rubocop_config', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'rubocop', '~> 1.66'

--- a/examples/create_spreadsheet/Rakefile
+++ b/examples/create_spreadsheet/Rakefile
@@ -38,13 +38,4 @@ CLOBBER << 'Gemfile.lock'
 
 require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new do |t|
-  t.options = %w[
-    --format fuubar
-    --format json --out rubocop-report.json
-    --display-cop-names
-    --config .rubocop.yml
-  ]
-end
-
-CLEAN << 'rubocop-report.json'
+RuboCop::RakeTask.new

--- a/spec/command_line_boss_steps.rb
+++ b/spec/command_line_boss_steps.rb
@@ -22,7 +22,7 @@ end
 
 step ':class_name defines the private instance method :method_name with the body:' do |class_name, method_name, body|
   klass = @klasses[class_name]
-  klass.define_method(method_name) { eval body } # rubocop:disable Lint/Eval
+  klass.define_method(method_name) { eval body } # rubocop:disable Security/Eval
   klass.send(:private, method_name)
 end
 


### PR DESCRIPTION
Update the .rubocop.yml to inherit from a shared Rubocop config from the main_branch_shared_rubocop_config gem.