### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.2.0 (2024-10-10)
+
+[Full Changelog](https://github.com/main-branch/command_line_boss/compare/v0.1.0..v0.2.0)
+
+Changes since v0.1.0:
+
+* 4a6ace7 build: remove semver pr label check
+* 05918a3 build: enforce conventional commit message formatting
+* e5f91d1 Clarify purpose of the gem in the README
+* ca16af0 Fix TargetRubyVersion Comment
+* 30eef5d Use shared Rubocop config
+* bbe9fe2 Update links in gemspec
+* c167adc Add Slack badge for this project in README
+* c442a80 Update yardopts with new standard options
+* f9be39f Standardize YARD and Markdown Lint configurations
+* bc7b9ae Update CODEOWNERS file
+* 3879f0a Set JRuby —debug option when running tests in GitHub Actions workflows
+* af10f27 Integrate simplecov-rspec into the project
+* 22b1364 Update continuous integration and experimental ruby builds
+* 2e2fa87 Enforce the use of semver tags on PRs
+* 4464e2c Fix CHANGELOG.md
+
 ## v0.1.0 (2024-07-03)
 
 [Full Changelog](https://github.com/main-branch/command_line_boss/compare/6cafbd0..v0.1.0)

--- a/lib/command_line_boss/version.rb
+++ b/lib/command_line_boss/version.rb
@@ -2,5 +2,5 @@
 
 class CommandLineBoss
   # Gem version
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
# Release PR

## v0.2.0 (2024-10-10)

[Full Changelog](https://github.com/main-branch/command_line_boss/compare/v0.1.0..v0.2.0)

Changes since v0.1.0:

* 4a6ace7 build: remove semver pr label check
* 05918a3 build: enforce conventional commit message formatting
* e5f91d1 Clarify purpose of the gem in the README
* ca16af0 Fix TargetRubyVersion Comment
* 30eef5d Use shared Rubocop config
* bbe9fe2 Update links in gemspec
* c167adc Add Slack badge for this project in README
* c442a80 Update yardopts with new standard options
* f9be39f Standardize YARD and Markdown Lint configurations
* bc7b9ae Update CODEOWNERS file
* 3879f0a Set JRuby —debug option when running tests in GitHub Actions workflows
* af10f27 Integrate simplecov-rspec into the project
* 22b1364 Update continuous integration and experimental ruby builds
* 2e2fa87 Enforce the use of semver tags on PRs
* 4464e2c Fix CHANGELOG.md
