### PR TITLE
Configure release-please for comprehensive CHANGELOG updates

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -4,13 +4,34 @@ extends: '@commitlint/config-conventional'
 rules:
   # See: https://commitlint.js.org/reference/rules.html
   #
-  # Rules are made up by a name and a configuration array. The configuration array contains:
+  # Rules are made up by a name and a configuration array. The configuration
+  # array contains:
   #
-  # * Severity [0..2]: 0 disable rule, 1 warning if violated, or 2 error if violated
+  # * Severity [0..2]: 0 disable rule, 1 warning if violated, or 2 error if
+  #   violated
   # * Applicability [always|never]: never inverts the rule
-  # * Value: value to use for this rule
+  # * Value: value to use for this rule (if applicable)
   #
-  # Run `npx commitlint --print-config` to see the current setting for all rules.
+  # Run `npx commitlint --print-config` to see the current setting for all
+  # rules.
   #
-  body-leading-blank:    [2, 'always']
-  footer-leading-blank:  [2, 'always']
+  header-max-length:      [2, always, 100]        # Header can not exceed 100 chars
+
+  type-case:              [2, always, lower-case] # Type must be lower case
+  type-empty:             [2, never]              # Type must not be empty
+
+  # Supported conventional commit types
+  type-enum:              [2, always, [build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test]]
+
+  scope-case:             [2, always, lower-case] # Scope must be lower case
+
+  # Error if subject is one of these cases (encourages lower-case)
+  subject-case:           [2, never, [sentence-case, start-case, pascal-case, upper-case]]
+  subject-empty:          [2, never]              # Subject must not be empty
+  subject-full-stop:      [2, never, "."]         # Subject must not end with a period
+
+  body-leading-blank:     [2, always]             # Body must have a blank line before it
+  body-max-line-length:   [2, always, 100]        # Body lines can not exceed 100 chars
+
+  footer-leading-blank:   [2, always]             # Footer must have a blank line before it
+  footer-max-line-length: [2, always, 100]        # Footer lines can not exceed 100 chars

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -1,4 +1,8 @@
+---
 name: Conventional Commits
+
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -9,6 +13,7 @@ jobs:
   commit-lint:
     name: Verify Conventional Commits
 
+    # Skip this job if this is a release PR
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,21 @@
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "pull-request-title-pattern": "chore: release v${version}",
+      "changelog-sections": [
+        { "type": "feat",     "section": "Features",      "hidden": false },
+        { "type": "fix",      "section": "Bug Fixes",     "hidden": false },
+        { "type": "build",    "section": "Other Changes", "hidden": false },
+        { "type": "chore",    "section": "Other Changes", "hidden": false },
+        { "type": "ci",       "section": "Other Changes", "hidden": false },
+        { "type": "docs",     "section": "Other Changes", "hidden": false },
+        { "type": "perf",     "section": "Other Changes", "hidden": false },
+        { "type": "refactor", "section": "Other Changes", "hidden": false },
+        { "type": "revert",   "section": "Other Changes", "hidden": false },
+        { "type": "style",    "section": "Other Changes", "hidden": false },
+        { "type": "test",     "section": "Other Changes", "hidden": false }
+      ]
     }
   },
   "plugins": [


### PR DESCRIPTION
Enhance the release-please configuration to display all change types in the CHANGELOG, including previously hidden types now categorized under "Other Changes." Explicitly list supported conventional commit types to ensure alignment with the configuration.